### PR TITLE
backend housekeeper

### DIFF
--- a/examples/k8s/be.yaml
+++ b/examples/k8s/be.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: joseki
   labels:
     app: joseki-backend
-    version: 0.2.0
+    version: 0.2.1
 data:
   config.yaml: |-
     database:
@@ -20,11 +20,16 @@ data:
       defaultTtl: 1
     
     watchmen:
-      scannerContainersPeriodicity: 600
+      scannerContainersPeriodicitySeconds: 1800
+      archiverPeriodicityHours: 24
+      archiveTtlDays: 90
     
     azureBlob:
       basePath: https://ACCOUNT_NAME.blob.core.windows.net
       sas: token
+      connectionString: DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix=core.windows.net
+      accountName: ACCOUNT_NAME
+      accountKey: ACCOUNT_KEY
     
     azureQueue:
       connectionString: DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix=core.windows.net
@@ -93,7 +98,7 @@ metadata:
   namespace: joseki
   labels:
     app: joseki-backend 
-    version: 0.2.0
+    version: 0.2.1
 spec:
   replicas: 1
   selector:
@@ -106,7 +111,7 @@ spec:
     spec:
       containers:
       - name: joseki-be
-        image: 'deepnetwork/joseki-backend:0.2.0'
+        image: 'deepnetwork/joseki-backend:0.2.1'
         imagePullPolicy: 'Always'
         name: joseki-be
         ports:

--- a/src/backend/dockerfile
+++ b/src/backend/dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 # Change to 8080 because 80 requires elevated privileges
+ENV ASPNETCORE_ENVIRONMENT="Production"
 ENV ASPNETCORE_URLS="http://*:8080"
 EXPOSE 8080
 

--- a/src/backend/joseki.be/tests/config.sample.yaml
+++ b/src/backend/joseki.be/tests/config.sample.yaml
@@ -10,11 +10,16 @@ cache:
   defaultTtl: 1
 
 watchmen:
-  scannerContainersPeriodicity: 600
+  scannerContainersPeriodicitySeconds: 1800
+  archiverPeriodicityHours: 24
+  archiveTtlDays: 90
 
 azureBlob:
   basePath: https://ACCOUNT_NAME.blob.core.windows.net
   sas: token
+  connectionString: DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix=core.windows.net
+  accountName: ACCOUNT_NAME
+  accountKey: ACCOUNT_KEY
 
 azureQueue:
   connectionString: DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix=core.windows.net

--- a/src/backend/joseki.be/webapp/BackgroundJobs/ArchiveWatchman.cs
+++ b/src/backend/joseki.be/webapp/BackgroundJobs/ArchiveWatchman.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Serilog;
+
+using webapp.BlobStorage;
+using webapp.Configuration;
+
+namespace webapp.BackgroundJobs
+{
+    /// <summary>
+    /// Archive processed audits and delete expired archive records.
+    /// </summary>
+    public class ArchiveWatchman
+    {
+        private static readonly ILogger Logger = Log.ForContext<ArchiveWatchman>();
+
+        private readonly IBlobStorageMaintainer blobStorage;
+        private readonly JosekiConfiguration config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArchiveWatchman"/> class.
+        /// </summary>
+        /// <param name="blobStorage">The Blob Storage.</param>
+        /// <param name="config">Joseki Backend configuration.</param>
+        public ArchiveWatchman(IBlobStorageMaintainer blobStorage, ConfigurationParser config)
+        {
+            this.blobStorage = blobStorage;
+            this.config = config.Get();
+        }
+
+        /// <summary>
+        /// Every Watchmen.ArchiverPeriodicityHours hours:
+        /// - removes expired audits from Archive,
+        /// - moves processed audits to Archive.
+        /// </summary>
+        /// <returns>A task object.</returns>
+        public async Task Watch(CancellationToken cancellation)
+        {
+            while (!cancellation.IsCancellationRequested)
+            {
+                try
+                {
+                    Logger.Information("Archiver watchman is going out.");
+
+                    try
+                    {
+                        // first, delete stale records, then move processed audits to archive
+                        // if the order is opposite - Cleanup task has a bit more work to do
+                        var deleted = await this.blobStorage.CleanupArchive(cancellation);
+                        var archived = await this.blobStorage.MoveProcessedBlobsToArchive(cancellation);
+
+                        Logger.Information("Archiver archived {ArchivedCount} and deleted {DeletedCount} blobs", archived, deleted);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "Archiver watchman failed now, but they comes back tomorrow");
+                    }
+
+                    Logger.Information("Archiver watchman finished the detour.");
+                    await Task.Delay(TimeSpan.FromHours(this.config.Watchmen.ArchiverPeriodicityHours), cancellation);
+                }
+                catch (TaskCanceledException ex)
+                {
+                    Logger.Information(ex, "Archiver watchman was canceled");
+                }
+            }
+        }
+    }
+}

--- a/src/backend/joseki.be/webapp/BackgroundJobs/ArchiverJob.cs
+++ b/src/backend/joseki.be/webapp/BackgroundJobs/ArchiverJob.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Serilog;
+
+namespace webapp.BackgroundJobs
+{
+    /// <summary>
+    /// The object is responsible for moving processed audits to Archive.
+    /// </summary>
+    public class ArchiverJob : BackgroundService
+    {
+        private static readonly ILogger Logger = Log.ForContext<ArchiverJob>();
+
+        private readonly IServiceProvider services;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArchiverJob"/> class.
+        /// </summary>
+        /// <param name="services">DI container.</param>
+        public ArchiverJob(IServiceProvider services)
+        {
+            this.services = services;
+        }
+
+        /// <inheritdoc />
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                Logger.Information("Starting archiver job");
+
+                using var scope = this.services.CreateScope();
+                var archiveWatchman = scope.ServiceProvider.GetRequiredService<ArchiveWatchman>();
+
+                await archiveWatchman.Watch(stoppingToken);
+
+                Logger.Information("Archiver job was finished");
+            }
+            catch (Exception ex)
+            {
+                Logger.Fatal(ex, "Archiver job failed");
+                throw;
+            }
+        }
+    }
+}

--- a/src/backend/joseki.be/webapp/BackgroundJobs/ScannerContainersWatchman.cs
+++ b/src/backend/joseki.be/webapp/BackgroundJobs/ScannerContainersWatchman.cs
@@ -61,7 +61,7 @@ namespace webapp.BackgroundJobs
                     this.scheduler.UpdateWorkingItems(schedulerItems);
 
                     Logger.Information("Scanner Containers watchman finished the detour.");
-                    await Task.Delay(TimeSpan.FromSeconds(this.config.Watchmen.ScannerContainersPeriodicity), cancellation);
+                    await Task.Delay(TimeSpan.FromSeconds(this.config.Watchmen.ScannerContainersPeriodicitySeconds), cancellation);
                 }
                 catch (TaskCanceledException ex)
                 {

--- a/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageMaintainer.cs
+++ b/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageMaintainer.cs
@@ -40,7 +40,6 @@ namespace webapp.BlobStorage
             this.storageClient = new BlobServiceClient(connectionString);
         }
 
-        /// <param name="cancellation"></param>
         /// <inheritdoc />
         public async Task<int> MoveProcessedBlobsToArchive(CancellationToken cancellation)
         {
@@ -154,7 +153,6 @@ namespace webapp.BlobStorage
             return deleteBlobTasks.Length;
         }
 
-        /// <param name="cancellation"></param>
         /// <inheritdoc />
         public async Task<int> CleanupArchive(CancellationToken cancellation)
         {

--- a/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageMaintainer.cs
+++ b/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageMaintainer.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+
+using Serilog;
+
+using webapp.Configuration;
+
+namespace webapp.BlobStorage
+{
+    /// <summary>
+    /// Azure blob storage implementation of IBlobStorageMaintainer.
+    /// </summary>
+    public class AzureBlobStorageMaintainer : IBlobStorageMaintainer
+    {
+        private const string ArchiveContainerName = "0-archive";
+
+        private const string ArchivedAtMetadataKeyName = "auditArchivedAt";
+
+        private static readonly ILogger Logger = Log.ForContext<AzureBlobStorageMaintainer>();
+
+        private readonly JosekiConfiguration config;
+        private readonly BlobServiceClient storageClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureBlobStorageMaintainer"/> class.
+        /// </summary>
+        /// <param name="parser">The application configuration object.</param>
+        public AzureBlobStorageMaintainer(ConfigurationParser parser)
+        {
+            this.config = parser.Get();
+            var connectionString = string.Format(this.config.AzureBlob.ConnectionString, this.config.AzureBlob.AccountName, this.config.AzureBlob.AccountKey);
+            this.storageClient = new BlobServiceClient(connectionString);
+        }
+
+        /// <param name="cancellation"></param>
+        /// <inheritdoc />
+        public async Task<int> MoveProcessedBlobsToArchive(CancellationToken cancellation)
+        {
+            Logger.Information("Archive processed audits was started");
+            var archiveContainerClient = this.storageClient.GetBlobContainerClient(ArchiveContainerName);
+
+            var blobsToCopy = new List<(AuditBlob blob, CopyFromUriOperation copyOperation)>();
+
+            await foreach (var container in this.storageClient.GetBlobContainersAsync(cancellationToken: cancellation))
+            {
+                // skip "system" containers
+                if (container.Name.StartsWith("0-"))
+                {
+                    continue;
+                }
+
+                var scannerContainerClient = this.storageClient.GetBlobContainerClient(container.Name);
+
+                var scannerContainer = new ScannerContainer(container.Name);
+                var regularBlobs = new List<string>();
+                var auditsToArchive = new Dictionary<string, List<string>>();
+
+                // Azure Storage stores all files inside container without any hierarchy. Thus joseki has to build the hierarchy here:
+                // - Find processed audits by presence of Processed tag on metadata file
+                // - All blobs, that have the same prefix as processed metadata file are moved to the same dictionary item
+                // - one dictionary item - is one audit folder
+                await foreach (var blob in scannerContainerClient.GetBlobsAsync(BlobTraits.Metadata, cancellationToken: cancellation))
+                {
+                    // not metadata files are stored in memory to be placed to corresponding dictionary cells later
+                    if (!blob.Name.EndsWith("meta") && blob.Name != container.Name)
+                    {
+                        regularBlobs.Add(blob.Name);
+                        continue;
+                    }
+
+                    // if metadata file has processed tag - create a dictionary key-value pair
+                    if (blob.Metadata == null || blob.Metadata.ContainsKey(AzureBlobStorageProcessor.ProcessedMetadataKey))
+                    {
+                        // the folder name is file_path without "/meta" at the end.
+                        var auditFolderName = blob.Name[..^5];
+                        auditsToArchive.Add(auditFolderName, new List<string> { blob.Name });
+                    }
+                }
+
+                // iterate through unsorted blob files and place them to dictionary items according to their prefix
+                foreach (var regularBlob in regularBlobs)
+                {
+                    var auditFolderName = regularBlob[..regularBlob.IndexOf('/')];
+                    if (auditsToArchive.TryGetValue(auditFolderName, out var fileNames))
+                    {
+                        fileNames.Add(regularBlob);
+                    }
+                }
+
+                // Move each audit folder to Archive container
+                // to move files, here is used Copy From URL method, which avoid loading blobs to joseki side
+                // https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob-from-url
+                // to generate the URL, joseki uses read-only SAS token with one hour expiration time.
+                foreach (var blobToArchive in auditsToArchive.SelectMany(i => i.Value))
+                {
+                    Logger.Information("Moving to archive {BlobPath}", $"{container.Name}/{blobToArchive}");
+
+                    var fileToCopyUri = $"{this.config.AzureBlob.BasePath}/{container.Name}/{blobToArchive}";
+
+                    var archiveBlobClient = archiveContainerClient.GetBlobClient($"{container.Name}/{blobToArchive}");
+                    var operation = await archiveBlobClient.StartCopyFromUriAsync(
+                        this.GetUniqueTemporarySasUrl(fileToCopyUri),
+                        new Dictionary<string, string>
+                        {
+                            { ArchivedAtMetadataKeyName, DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString() },
+                        },
+                        cancellationToken: cancellation);
+                    blobsToCopy.Add((new AuditBlob { Name = blobToArchive, ParentContainer = scannerContainer }, operation));
+                }
+            }
+
+            // wait copy operations to complete, but not more than 1 hour
+            var linkedTokens = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellation,
+                new CancellationTokenSource(TimeSpan.FromHours(1)).Token);
+            foreach (var (_, copyOperation) in blobsToCopy)
+            {
+                await copyOperation.WaitForCompletionAsync(linkedTokens.Token);
+            }
+
+            // each copied blob could be deleted
+            var deleteBlobTasks = blobsToCopy
+                .Where(i => i.copyOperation.HasCompleted)
+                .Select(i => this.DeleteBlob(i.blob))
+                .ToArray();
+            await Task.WhenAll(deleteBlobTasks);
+
+            // TODO: retry operations automatically?
+            // TODO: also, consider moving in two stages: first move all not metadata files, the second - move metadata too.
+            // but now only log errors
+            if (deleteBlobTasks.Length != blobsToCopy.Count)
+            {
+                var blobPaths = blobsToCopy
+                    .Where(i => i.copyOperation.HasCompleted)
+                    .Select(i => $"{i.blob.ParentContainer.Name}/{i.blob.Name}");
+
+                Logger.Error("{FailedCount} blobs failed to be moved to Archive:", blobsToCopy.Count - deleteBlobTasks.Length);
+                foreach (var blobPath in blobPaths)
+                {
+                    Logger.Warning("Blob {BlobPath} failed to be copied", blobPath);
+                }
+            }
+
+            Logger.Information("Archive processed audits was finished");
+
+            return deleteBlobTasks.Length;
+        }
+
+        /// <param name="cancellation"></param>
+        /// <inheritdoc />
+        public async Task<int> CleanupArchive(CancellationToken cancellation)
+        {
+            Logger.Information("Archive cleanup was {State}", "started");
+            var deletedBlobs = 0;
+
+            var archiveContainerClient = this.storageClient.GetBlobContainerClient(ArchiveContainerName);
+
+            var expirationTime = DateTimeOffset
+                .UtcNow
+                .AddDays(-this.config.Watchmen.ArchiveTtlDays)
+                .ToUnixTimeSeconds();
+
+            await foreach (var blob in archiveContainerClient.GetBlobsAsync(BlobTraits.Metadata, cancellationToken: cancellation))
+            {
+                try
+                {
+                    var unixEpoch = long.Parse(blob.Metadata[ArchivedAtMetadataKeyName]);
+                    if (unixEpoch < expirationTime)
+                    {
+                        Logger.Information("Deleting blob {BlobPath} from Archive", blob.Name);
+                        deletedBlobs++;
+                        await archiveContainerClient.DeleteBlobAsync(blob.Name, cancellationToken: cancellation);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // it should not happen normally, so it should not stop other blobs from processing :)
+                    // but just in case, here is the logger
+                    Logger.Warning(ex, "Failed to parse archive-date from {BlobPath}", blob.Name);
+                }
+            }
+
+            Logger.Information("Archive cleanup was {State}", "finished");
+
+            return deletedBlobs;
+        }
+
+        /// <summary>
+        /// Deletes everything from the container.
+        /// </summary>
+        /// <returns>A task object.</returns>
+        public async Task CleanupContainer(ScannerContainer container)
+        {
+            var uri = new Uri($"{this.config.AzureBlob.BasePath}/{container.Name}?{this.config.AzureBlob.Sas}");
+            var client = new BlobContainerClient(uri);
+
+            await foreach (var blob in client.GetBlobsAsync())
+            {
+                if (blob.Name == container.Name)
+                {
+                    continue;
+                }
+
+                await client.GetBlobClient(blob.Name).DeleteAsync(DeleteSnapshotsOption.IncludeSnapshots);
+            }
+        }
+
+        private Uri GetUniqueTemporarySasUrl(string blobUri)
+        {
+            // Create a service level SAS that only allows reading
+            var sas = new AccountSasBuilder
+            {
+                Services = AccountSasServices.Blobs,
+                ResourceTypes = AccountSasResourceTypes.Object,
+                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+            };
+            sas.SetPermissions(AccountSasPermissions.Read);
+
+            var credential = new StorageSharedKeyCredential(this.config.AzureBlob.AccountName, this.config.AzureBlob.AccountKey);
+
+            var sasUri = new UriBuilder(blobUri)
+            {
+                Query = sas.ToSasQueryParameters(credential).ToString(),
+            };
+
+            return sasUri.Uri;
+        }
+
+        private async Task DeleteBlob(AuditBlob blob)
+        {
+            var uri = new Uri($"{this.config.AzureBlob.BasePath}/{blob.ParentContainer.Name}?{this.config.AzureBlob.Sas}");
+            var client = new BlobContainerClient(uri);
+            await client.GetBlobClient(blob.Name).DeleteAsync(DeleteSnapshotsOption.IncludeSnapshots);
+        }
+    }
+}

--- a/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageProcessor.cs
+++ b/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageProcessor.cs
@@ -39,7 +39,11 @@ namespace webapp.BlobStorage
             var containers = new List<ScannerContainer>();
             await foreach (var container in client.GetBlobContainersAsync())
             {
-                containers.Add(new ScannerContainer(container.Name));
+                // skip "system" containers
+                if (!container.Name.StartsWith("0-"))
+                {
+                    containers.Add(new ScannerContainer(container.Name));
+                }
             }
 
             return containers.ToArray();

--- a/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageProcessor.cs
+++ b/src/backend/joseki.be/webapp/BlobStorage/AzureBlobStorageProcessor.cs
@@ -14,7 +14,10 @@ namespace webapp.BlobStorage
     /// </summary>
     public class AzureBlobStorageProcessor : IBlobStorageProcessor
     {
-        private const string ProcessedMetadataKey = "processed";
+        /// <summary>
+        /// Metadata tag name for "processed" audits.
+        /// </summary>
+        public const string ProcessedMetadataKey = "processed";
 
         private readonly JosekiConfiguration config;
 
@@ -93,12 +96,11 @@ namespace webapp.BlobStorage
         /// </summary>
         /// <param name="container">The container with audits.</param>
         /// <returns>Array of Audit blobs.</returns>
-        public async Task<AuditBlob[]> GetAllAudits(ScannerContainer container)
+        public async Task MarkAllAuditsAsUnprocessed(ScannerContainer container)
         {
             var uri = new Uri($"{this.config.AzureBlob.BasePath}/{container.Name}?{this.config.AzureBlob.Sas}");
             var client = new Azure.Storage.Blobs.BlobContainerClient(uri);
 
-            var blobs = new List<AuditBlob>();
             await foreach (var blob in client.GetBlobsAsync())
             {
                 // skip all not metadata file.
@@ -107,26 +109,8 @@ namespace webapp.BlobStorage
                     continue;
                 }
 
-                blobs.Add(new AuditBlob
-                {
-                    Name = blob.Name,
-                    ParentContainer = container,
-                });
+                await client.GetBlobClient(blob.Name).SetMetadataAsync(new Dictionary<string, string>());
             }
-
-            return blobs.ToArray();
-        }
-
-        /// <summary>
-        /// Cleans-up Processed tag.
-        /// </summary>
-        /// <param name="auditBlob">Audit blob to remove Processed tag.</param>
-        /// <returns>A task object.</returns>
-        public async Task MarkAsUnprocessed(AuditBlob auditBlob)
-        {
-            var uri = new Uri($"{this.config.AzureBlob.BasePath}/{auditBlob.ParentContainer.Name}/{auditBlob.Name}?{this.config.AzureBlob.Sas}");
-            var client = new Azure.Storage.Blobs.BlobClient(uri);
-            await client.SetMetadataAsync(new Dictionary<string, string>());
         }
     }
 }

--- a/src/backend/joseki.be/webapp/BlobStorage/IBlobStorageMaintainer.cs
+++ b/src/backend/joseki.be/webapp/BlobStorage/IBlobStorageMaintainer.cs
@@ -10,6 +10,7 @@ namespace webapp.BlobStorage
     {
         /// <summary>
         /// Moves all processed audit blobs from scanner containers to Archive container.
+        /// The process keeps scanner containers working set small, which reduces amount of processors work.
         /// </summary>
         /// <param name="cancellation">Cancellation token.</param>
         /// <returns>Number of records, that were moved to Archive.</returns>

--- a/src/backend/joseki.be/webapp/BlobStorage/IBlobStorageMaintainer.cs
+++ b/src/backend/joseki.be/webapp/BlobStorage/IBlobStorageMaintainer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace webapp.BlobStorage
 {
@@ -8,30 +9,17 @@ namespace webapp.BlobStorage
     public interface IBlobStorageMaintainer
     {
         /// <summary>
-        /// Moves audit blob from scanner container to Archive container.
+        /// Moves all processed audit blobs from scanner containers to Archive container.
         /// </summary>
-        /// <param name="blob">Audit blob object.</param>
-        /// <returns>A task object.</returns>
-        Task MoveToArchive(AuditBlob blob);
+        /// <param name="cancellation">Cancellation token.</param>
+        /// <returns>Number of records, that were moved to Archive.</returns>
+        Task<int> MoveProcessedBlobsToArchive(CancellationToken cancellation);
 
         /// <summary>
-        /// Moves blob from Archive to Garbage Bin.
+        /// Deletes all expired blobs from Archive.
         /// </summary>
-        /// <param name="blob">Audit blob object.</param>
-        /// <returns>A task object.</returns>
-        Task DeleteStale(AuditBlob blob);
-
-        /// <summary>
-        /// Moves the entire scanner container to Garbage Bin.
-        /// </summary>
-        /// <param name="container">Scanner container object.</param>
-        /// <returns>A task object.</returns>
-        Task DeleteStale(ScannerContainer container);
-
-        /// <summary>
-        /// Deletes all expired blobs from Garbage Bin.
-        /// </summary>
-        /// <returns>A task object.</returns>
-        Task CleanupGarbageBin();
+        /// <param name="cancellation">Cancellation token.</param>
+        /// <returns>Number of records, that were removed from Archive.</returns>
+        Task<int> CleanupArchive(CancellationToken cancellation);
     }
 }

--- a/src/backend/joseki.be/webapp/Configuration/JosekiConfiguration.cs
+++ b/src/backend/joseki.be/webapp/Configuration/JosekiConfiguration.cs
@@ -128,7 +128,7 @@
         /// How often ScannerContainersWatchman is listing root-level containers.
         /// The measurement is in seconds.
         /// </summary>
-        public int ScannerContainersPeriodicity { get; set; }
+        public int ScannerContainersPeriodicitySeconds { get; set; } = 1800;
 
         /// <summary>
         /// How often ArchiveWatchman is maintaining the Archive.

--- a/src/backend/joseki.be/webapp/Configuration/JosekiConfiguration.cs
+++ b/src/backend/joseki.be/webapp/Configuration/JosekiConfiguration.cs
@@ -102,6 +102,21 @@
         /// Sas token.
         /// </summary>
         public string Sas { get; set; }
+
+        /// <summary>
+        /// Azure Storage connection string.
+        /// </summary>
+        public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Storage Account name.
+        /// </summary>
+        public string AccountName { get; set; }
+
+        /// <summary>
+        /// Storage Account key.
+        /// </summary>
+        public string AccountKey { get; set; }
     }
 
     /// <summary>
@@ -114,6 +129,18 @@
         /// The measurement is in seconds.
         /// </summary>
         public int ScannerContainersPeriodicity { get; set; }
+
+        /// <summary>
+        /// How often ArchiveWatchman is maintaining the Archive.
+        /// The measurement is in hours.
+        /// </summary>
+        public int ArchiverPeriodicityHours { get; set; } = 24;
+
+        /// <summary>
+        /// How long processed audits should be stored in Archive.
+        /// The measurement is in days.
+        /// </summary>
+        public int ArchiveTtlDays { get; set; } = 90;
     }
 
     /// <summary>

--- a/src/backend/joseki.be/webapp/Program.cs
+++ b/src/backend/joseki.be/webapp/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 
 namespace webapp
@@ -12,6 +13,8 @@ namespace webapp
     /// </summary>
     public class Program
     {
+        internal static LoggingLevelSwitch LoggingLevelSwitch { get; set; } = new LoggingLevelSwitch();
+
         /// <summary>
         /// The entry point.
         /// </summary>
@@ -34,7 +37,7 @@ namespace webapp
                 .UseSerilog((ctx, config) =>
                 {
                     config
-                        .MinimumLevel.Information()
+                        .MinimumLevel.ControlledBy(LoggingLevelSwitch)
                         .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                         .MinimumLevel.Override("System", LogEventLevel.Warning)
                         .Enrich.FromLogContext();

--- a/src/backend/joseki.be/webapp/Startup.cs
+++ b/src/backend/joseki.be/webapp/Startup.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 
+using Serilog.Events;
+
 using webapp.Audits.Processors.azsk;
 using webapp.Audits.Processors.polaris;
 using webapp.Audits.Processors.trivy;
@@ -126,6 +128,7 @@ namespace webapp
         {
             if (env.IsDevelopment())
             {
+                Program.LoggingLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 app.UseDeveloperExceptionPage();
             }
 

--- a/src/backend/joseki.be/webapp/Startup.cs
+++ b/src/backend/joseki.be/webapp/Startup.cs
@@ -89,6 +89,7 @@ namespace webapp
             });
 
             services.AddTransient<IBlobStorageProcessor, AzureBlobStorageProcessor>();
+            services.AddTransient<IBlobStorageMaintainer, AzureBlobStorageMaintainer>();
             services.AddTransient<IQueue, AzureStorageQueue>();
 
             services.AddDbContext<JosekiDbContext>((provider, options) =>
@@ -112,6 +113,8 @@ namespace webapp
             services.AddScoped<ScannerContainersWatchman>();
             services.AddSingleton<SchedulerAssistant>();
             services.AddHostedService<ScannerResultsReaderJob>();
+            services.AddScoped<ArchiveWatchman>();
+            services.AddHostedService<ArchiverJob>();
         }
 
         /// <summary>

--- a/src/backend/joseki.be/webapp/webapp.xml
+++ b/src/backend/joseki.be/webapp/webapp.xml
@@ -400,6 +400,22 @@
             Returns the point of time, when the container should be processed.
             </summary>
         </member>
+        <member name="M:webapp.BackgroundJobs.SchedulerAssistant.SchedulableItem.StartNewIteration">
+             <summary>
+             The fundamental problem - once in a while, joseki should write log messages.
+             BUT, if joseki writes on each iteration of scanner processor - logs might be flooded with meaningless events.
+             For example, Trivy scanner-processors are executed each minute, which leads to 3*60 log-events each hour.
+            
+             To reduce the noise, this method helps to switch log-level from Debug to Information each hour.
+             </summary>
+        </member>
+        <member name="M:webapp.BackgroundJobs.SchedulerAssistant.SchedulableItem.GetLogEventLevel">
+            <summary>
+            If iteration should be logged _globally_ - returns Information log-level.
+            Otherwise - returns Debug.
+            </summary>
+            <returns>Serilog log-level enumeration.</returns>
+        </member>
         <member name="T:webapp.BlobStorage.AuditBlob">
             <summary>
             Describes a single audit folder within a scanner container.
@@ -427,11 +443,9 @@
             <param name="parser">The application configuration object.</param>
         </member>
         <member name="M:webapp.BlobStorage.AzureBlobStorageMaintainer.MoveProcessedBlobsToArchive(System.Threading.CancellationToken)">
-            <param name="cancellation"></param>
             <inheritdoc />
         </member>
         <member name="M:webapp.BlobStorage.AzureBlobStorageMaintainer.CleanupArchive(System.Threading.CancellationToken)">
-            <param name="cancellation"></param>
             <inheritdoc />
         </member>
         <member name="M:webapp.BlobStorage.AzureBlobStorageMaintainer.CleanupContainer(webapp.BlobStorage.ScannerContainer)">
@@ -483,6 +497,7 @@
         <member name="M:webapp.BlobStorage.IBlobStorageMaintainer.MoveProcessedBlobsToArchive(System.Threading.CancellationToken)">
             <summary>
             Moves all processed audit blobs from scanner containers to Archive container.
+            The process keeps scanner containers working set small, which reduces amount of processors work.
             </summary>
             <param name="cancellation">Cancellation token.</param>
             <returns>Number of records, that were moved to Archive.</returns>

--- a/src/backend/joseki.be/webapp/webapp.xml
+++ b/src/backend/joseki.be/webapp/webapp.xml
@@ -277,6 +277,40 @@
             Represents azsk scanner.
             </summary>
         </member>
+        <member name="T:webapp.BackgroundJobs.ArchiverJob">
+            <summary>
+            The object is responsible for moving processed audits to Archive.
+            </summary>
+        </member>
+        <member name="M:webapp.BackgroundJobs.ArchiverJob.#ctor(System.IServiceProvider)">
+            <summary>
+            Initializes a new instance of the <see cref="T:webapp.BackgroundJobs.ArchiverJob"/> class.
+            </summary>
+            <param name="services">DI container.</param>
+        </member>
+        <member name="M:webapp.BackgroundJobs.ArchiverJob.ExecuteAsync(System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="T:webapp.BackgroundJobs.ArchiveWatchman">
+            <summary>
+            Archive processed audits and delete expired archive records.
+            </summary>
+        </member>
+        <member name="M:webapp.BackgroundJobs.ArchiveWatchman.#ctor(webapp.BlobStorage.IBlobStorageMaintainer,webapp.Configuration.ConfigurationParser)">
+            <summary>
+            Initializes a new instance of the <see cref="T:webapp.BackgroundJobs.ArchiveWatchman"/> class.
+            </summary>
+            <param name="blobStorage">The Blob Storage.</param>
+            <param name="config">Joseki Backend configuration.</param>
+        </member>
+        <member name="M:webapp.BackgroundJobs.ArchiveWatchman.Watch(System.Threading.CancellationToken)">
+            <summary>
+            Every Watchmen.ArchiverPeriodicityHours hours:
+            - removes expired audits from Archive,
+            - moves processed audits to Archive.
+            </summary>
+            <returns>A task object.</returns>
+        </member>
         <member name="T:webapp.BackgroundJobs.ScannerContainersWatchman">
             <summary>
             ScannerContainers watchman is responsible for following actual state of root-level containers in Blob Storage
@@ -381,9 +415,39 @@
             Parent scanner container.
             </summary>
         </member>
+        <member name="T:webapp.BlobStorage.AzureBlobStorageMaintainer">
+            <summary>
+            Azure blob storage implementation of IBlobStorageMaintainer.
+            </summary>
+        </member>
+        <member name="M:webapp.BlobStorage.AzureBlobStorageMaintainer.#ctor(webapp.Configuration.ConfigurationParser)">
+            <summary>
+            Initializes a new instance of the <see cref="T:webapp.BlobStorage.AzureBlobStorageMaintainer"/> class.
+            </summary>
+            <param name="parser">The application configuration object.</param>
+        </member>
+        <member name="M:webapp.BlobStorage.AzureBlobStorageMaintainer.MoveProcessedBlobsToArchive(System.Threading.CancellationToken)">
+            <param name="cancellation"></param>
+            <inheritdoc />
+        </member>
+        <member name="M:webapp.BlobStorage.AzureBlobStorageMaintainer.CleanupArchive(System.Threading.CancellationToken)">
+            <param name="cancellation"></param>
+            <inheritdoc />
+        </member>
+        <member name="M:webapp.BlobStorage.AzureBlobStorageMaintainer.CleanupContainer(webapp.BlobStorage.ScannerContainer)">
+            <summary>
+            Deletes everything from the container.
+            </summary>
+            <returns>A task object.</returns>
+        </member>
         <member name="T:webapp.BlobStorage.AzureBlobStorageProcessor">
             <summary>
             Azure Blob Storage implementation of Blob Storage Processor.
+            </summary>
+        </member>
+        <member name="F:webapp.BlobStorage.AzureBlobStorageProcessor.ProcessedMetadataKey">
+            <summary>
+            Metadata tag name for "processed" audits.
             </summary>
         </member>
         <member name="M:webapp.BlobStorage.AzureBlobStorageProcessor.#ctor(webapp.Configuration.ConfigurationParser)">
@@ -404,51 +468,31 @@
         <member name="M:webapp.BlobStorage.AzureBlobStorageProcessor.MarkAsProcessed(webapp.BlobStorage.AuditBlob)">
             <inheritdoc />
         </member>
-        <member name="M:webapp.BlobStorage.AzureBlobStorageProcessor.GetAllAudits(webapp.BlobStorage.ScannerContainer)">
+        <member name="M:webapp.BlobStorage.AzureBlobStorageProcessor.MarkAllAuditsAsUnprocessed(webapp.BlobStorage.ScannerContainer)">
             <summary>
             The method returns all audit files in the container.
             </summary>
             <param name="container">The container with audits.</param>
             <returns>Array of Audit blobs.</returns>
         </member>
-        <member name="M:webapp.BlobStorage.AzureBlobStorageProcessor.MarkAsUnprocessed(webapp.BlobStorage.AuditBlob)">
-            <summary>
-            Cleans-up Processed tag.
-            </summary>
-            <param name="auditBlob">Audit blob to remove Processed tag.</param>
-            <returns>A task object.</returns>
-        </member>
         <member name="T:webapp.BlobStorage.IBlobStorageMaintainer">
             <summary>
             Takes care of managing Archive and Garbage Bin in the Blob Storage service.
             </summary>
         </member>
-        <member name="M:webapp.BlobStorage.IBlobStorageMaintainer.MoveToArchive(webapp.BlobStorage.AuditBlob)">
+        <member name="M:webapp.BlobStorage.IBlobStorageMaintainer.MoveProcessedBlobsToArchive(System.Threading.CancellationToken)">
             <summary>
-            Moves audit blob from scanner container to Archive container.
+            Moves all processed audit blobs from scanner containers to Archive container.
             </summary>
-            <param name="blob">Audit blob object.</param>
-            <returns>A task object.</returns>
+            <param name="cancellation">Cancellation token.</param>
+            <returns>Number of records, that were moved to Archive.</returns>
         </member>
-        <member name="M:webapp.BlobStorage.IBlobStorageMaintainer.DeleteStale(webapp.BlobStorage.AuditBlob)">
+        <member name="M:webapp.BlobStorage.IBlobStorageMaintainer.CleanupArchive(System.Threading.CancellationToken)">
             <summary>
-            Moves blob from Archive to Garbage Bin.
+            Deletes all expired blobs from Archive.
             </summary>
-            <param name="blob">Audit blob object.</param>
-            <returns>A task object.</returns>
-        </member>
-        <member name="M:webapp.BlobStorage.IBlobStorageMaintainer.DeleteStale(webapp.BlobStorage.ScannerContainer)">
-            <summary>
-            Moves the entire scanner container to Garbage Bin.
-            </summary>
-            <param name="container">Scanner container object.</param>
-            <returns>A task object.</returns>
-        </member>
-        <member name="M:webapp.BlobStorage.IBlobStorageMaintainer.CleanupGarbageBin">
-            <summary>
-            Deletes all expired blobs from Garbage Bin.
-            </summary>
-            <returns>A task object.</returns>
+            <param name="cancellation">Cancellation token.</param>
+            <returns>Number of records, that were removed from Archive.</returns>
         </member>
         <member name="T:webapp.BlobStorage.IBlobStorageProcessor">
             <summary>
@@ -632,6 +676,21 @@
             Sas token.
             </summary>
         </member>
+        <member name="P:webapp.Configuration.AzureBlobConfig.ConnectionString">
+            <summary>
+            Azure Storage connection string.
+            </summary>
+        </member>
+        <member name="P:webapp.Configuration.AzureBlobConfig.AccountName">
+            <summary>
+            Storage Account name.
+            </summary>
+        </member>
+        <member name="P:webapp.Configuration.AzureBlobConfig.AccountKey">
+            <summary>
+            Storage Account key.
+            </summary>
+        </member>
         <member name="T:webapp.Configuration.Watchmen">
             <summary>
             Watchmen related configurations.
@@ -641,6 +700,18 @@
             <summary>
             How often ScannerContainersWatchman is listing root-level containers.
             The measurement is in seconds.
+            </summary>
+        </member>
+        <member name="P:webapp.Configuration.Watchmen.ArchiverPeriodicityHours">
+            <summary>
+            How often ArchiveWatchman is maintaining the Archive.
+            The measurement is in hours.
+            </summary>
+        </member>
+        <member name="P:webapp.Configuration.Watchmen.ArchiveTtlDays">
+            <summary>
+            How long processed audits should be stored in Archive.
+            The measurement is in days.
             </summary>
         </member>
         <member name="T:webapp.Configuration.AzureQueueConfig">


### PR DESCRIPTION
Completes the last parts of #22

- moves processed audits to Archive;
- cleans up blobs older than 90 days from Archive;
- reduce noise in logs;
- corrected scheduler-assistant generations;
- switchable log-level
- next version of docker image