### PR TITLE
Several backend corrections

### DIFF
--- a/src/backend/joseki.be/webapp/BackgroundJobs/InfraScoreCacheReloaderJob.cs
+++ b/src/backend/joseki.be/webapp/BackgroundJobs/InfraScoreCacheReloaderJob.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 using Serilog;
@@ -34,9 +33,7 @@ namespace webapp.BackgroundJobs
             {
                 Logger.Information("Starting infra-score cache-reloader job");
 
-                using var scope = this.services.CreateScope();
-                var watchman = scope.ServiceProvider.GetRequiredService<InfraScoreCacheWatchman>();
-
+                var watchman = new InfraScoreCacheWatchman(this.services);
                 await watchman.Watch(stoppingToken);
 
                 Logger.Information("Infra-score cache-reloader job was finished");

--- a/src/backend/joseki.be/webapp/BackgroundJobs/SchedulerAssistant.cs
+++ b/src/backend/joseki.be/webapp/BackgroundJobs/SchedulerAssistant.cs
@@ -73,12 +73,17 @@ namespace webapp.BackgroundJobs
                             await Task.Delay(delay, cancellation);
                         }
 
-                        using (var serviceScope = this.services.CreateScope())
+                        try
                         {
+                            using var serviceScope = this.services.CreateScope();
                             var auditProcessor = GetProcessor(serviceScope, item.Container.Metadata);
                             await auditProcessor.Process(item.Container, cancellation);
 
                             item.LastProcessed = DateTime.UtcNow;
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Warning(ex, "Scheduler Assistant encountered unexpected exception during processing {ContainerName}", item.Container.Name);
                         }
 
                         Logger.Write(item.GetLogEventLevel(), "Scheduler has processed {ContainerName}", item.Container.Name);

--- a/src/backend/joseki.be/webapp/Database/MssqlJosekiDatabase.cs
+++ b/src/backend/joseki.be/webapp/Database/MssqlJosekiDatabase.cs
@@ -141,6 +141,7 @@ namespace webapp.Database
             var theDay = date.Date;
             var theNextDay = theDay.AddDays(1);
             var componentIds = await this.db.Set<AuditEntity>()
+                .AsNoTracking()
                 .Where(i => i.Date >= theDay && i.Date < theNextDay)
                 .Select(i => i.ComponentId)
                 .Distinct()

--- a/src/backend/joseki.be/webapp/Startup.cs
+++ b/src/backend/joseki.be/webapp/Startup.cs
@@ -133,10 +133,10 @@ namespace webapp
 
             services.AddSingleton<IMemoryCache, MemoryCache>();
             services.AddScoped<IJosekiDatabase, MssqlJosekiDatabase>();
-            services.AddTransient<ChecksCache>();
-            services.AddTransient<CveCache>();
             services.AddScoped<IInfraScoreDbWrapper, InfraScoreDbWrapper>();
             services.AddTransient<IInfrastructureScoreCache, InfrastructureScoreCache>();
+            services.AddTransient<ChecksCache>();
+            services.AddTransient<CveCache>();
 
             services.AddTransient<AzskAuditProcessor>();
             services.AddTransient<PolarisAuditProcessor>();
@@ -150,7 +150,7 @@ namespace webapp
             services.AddTransient<GetKnowledgebaseItemsHandler>();
 
             services.AddScoped<ScannerContainersWatchman>();
-            services.AddSingleton<SchedulerAssistant>();
+            services.AddScoped<SchedulerAssistant>();
             services.AddScoped<ArchiveWatchman>();
             services.AddScoped<InfraScoreCacheWatchman>();
 

--- a/src/backend/joseki.be/webapp/webapp.xml
+++ b/src/backend/joseki.be/webapp/webapp.xml
@@ -362,12 +362,11 @@
             Regularly reloads Infrastructure Score cache items.
             </summary>
         </member>
-        <member name="M:webapp.BackgroundJobs.InfraScoreCacheWatchman.#ctor(webapp.Database.Cache.IInfrastructureScoreCache,webapp.Configuration.ConfigurationParser)">
+        <member name="M:webapp.BackgroundJobs.InfraScoreCacheWatchman.#ctor(System.IServiceProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:webapp.BackgroundJobs.InfraScoreCacheWatchman"/> class.
             </summary>
-            <param name="cache">The cache.</param>
-            <param name="config">Joseki Backend configuration.</param>
+            <param name="services">DI container.</param>
         </member>
         <member name="M:webapp.BackgroundJobs.InfraScoreCacheWatchman.Watch(System.Threading.CancellationToken)">
             <summary>


### PR DESCRIPTION
- failed audit processor should not stop others
- use a new instance of db at each infra-score-cache reload iteration
- ensure AsNoTracking is called at each read-only scenario