### PR TITLE
ownership metadata does not accept emails.

### DIFF
--- a/examples/k8s/frontend/fe.yaml
+++ b/examples/k8s/frontend/fe.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: joseki
   labels:
     app: joseki-frontend
-    owner: umut.celenli@deepnetwork.com
+    owner: umut.celenli
   annotations:
 spec:
   ports:
@@ -42,7 +42,7 @@ metadata:
   labels:
     app: joseki-frontend
     version: '#{fe.imageTag}#'
-    owner: umut.celenli@deepnetwork.com
+    owner: umut.celenli
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
replaced my email with just name within owner label of fe.yaml

`a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`
