### PR TITLE
fix(be) - downgrade Azure.Storage.Blobs to 12.4:

### DIFF
--- a/src/backend/joseki.be/webapp/webapp.csproj
+++ b/src/backend/joseki.be/webapp/webapp.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.5.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.4.4" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />


### PR DESCRIPTION
Version 12.5 changes behavior for traversing blobs and parsing SAS tokens,
which causes runtime exceptions in Archiver.

Unfortunatelly, I have no time to debug and fix the issue, therefore - revert